### PR TITLE
v1.5.8

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,6 +19,11 @@ on:
         required: false
         default: false
         type: boolean
+      separate_forge:
+        description: 'If false, separate Modrinth Forge mod version will not be uploaded'
+        required: false
+        default: true
+        type: boolean
 
 jobs:
   deploy:
@@ -250,6 +255,29 @@ jobs:
             datapack
           files: |
             ./${{ github.event.repository.name }}-v${{ github.event.inputs.tag }}-mc${{ env.MC_HUMAN_VERSION_RANGE }}-datapack.zip
+
+      - name: Upload Forge mod version to Modrinth # Forge mod version is uploaded separately due to it not being compatible with Minecraft 1.21.6 or above
+        id: upload_forge_modrinth_mod
+        uses: Kir-Antipov/mc-publish@v3.3
+        if: steps.check_mod_folder.outputs.files_exists == 'true' && github.event.inputs.dry_run == 'false' && github.event.inputs.separate_forge == 'true'
+        with:
+          modrinth-id: HJR6V0I2
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          game-versions: |
+            >=1.17 <=1.21.5
+          game-version-filter: any
+          fail-mode: skip
+
+          name: "[Mod] Release v${{ github.event.inputs.tag }}"
+          version: ${{ github.event.inputs.tag }}+mod
+          changelog-file: CHANGES.md
+
+          dependencies: |
+            midnightlib(optional){modrinth:codAaoxh}
+          loaders: |
+            forge
+          files: |
+            ./${{ github.event.repository.name }}-v${{ github.event.inputs.tag }}-mc${{ env.MC_HUMAN_VERSION_RANGE }}-mod.jar
       
       - name: Upload mod version to Modrinth
         id: upload_modrinth_mod
@@ -275,7 +303,6 @@ jobs:
           loaders: |
             fabric
             quilt
-            forge
             neoforge
           files: |
             ./${{ github.event.repository.name }}-v${{ github.event.inputs.tag }}-mc${{ env.MC_HUMAN_VERSION_RANGE }}-mod.jar
@@ -326,7 +353,6 @@ jobs:
           loaders: |
             fabric
             quilt
-            forge
             neoforge
           files: |
             ./${{ github.event.repository.name }}-v${{ github.event.inputs.tag }}-mc${{ env.MC_HUMAN_VERSION_RANGE }}-mod.jar

--- a/.spyglassrc.json
+++ b/.spyglassrc.json
@@ -1,5 +1,5 @@
 {
   "env": {
-    "gameVersion": "1.21.9"
+    "gameVersion": "1.21.11"
   }
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
-- **Added support for Minecraft 1.21.9** 🥉
-  - Updated to work with the new pack.mcmeta syntax
-- Fixed an oversight that was preventing the second Frozen Zombie variant from spawning (closes [#27](https://github.com/Tschipcraft/more_mobs/issues/27))
+- **Added support for Minecraft 1.21.11** 🐎
+  - Updated rain detection to use our own `#is_dry` biome tag combo instead of the now removed `#snow_golem_melts` tag
+  - Removed broken hide feedback code for 1.21+
+  - Bumped pack format and protocol version

--- a/META-INF/mods.toml
+++ b/META-INF/mods.toml
@@ -26,7 +26,7 @@ features={ java_version = "[8,)" }
 [[dependencies.moremobs]]
     modId="minecraft"
     mandatory=true
-    versionRange="${mc_version_range_forge}"
+    versionRange="[1.17,1.21.5]"
     ordering="NONE"
     side="BOTH"
 

--- a/data/more_mobs/function/general/set_on_fire_1194/exec.mcfunction
+++ b/data/more_mobs/function/general/set_on_fire_1194/exec.mcfunction
@@ -2,4 +2,4 @@
 # Sets mobs with a custom head on fire if they are standing under the sunlight. This is a exclusive feature for Minecraft 1.19.4 and up.
 
 execute unless predicate more_mobs:is_raining run data modify entity @s Fire set value 160s
-execute if predicate more_mobs:is_raining if biome ~ ~ ~ #minecraft:snow_golem_melts unless predicate more_mobs:is_thundering run data modify entity @s Fire set value 160s
+execute if predicate more_mobs:is_raining if biome ~ ~ ~ #more_mobs:is_dry unless predicate more_mobs:is_thundering run data modify entity @s Fire set value 160s

--- a/data/more_mobs/function/settings/core.mcfunction
+++ b/data/more_mobs/function/settings/core.mcfunction
@@ -33,5 +33,4 @@ execute if score $mobs_burn ts.mm.settings matches 0 run tellraw @s ["",{"text":
 execute if score $mobs_burn ts.mm.settings matches -1 run tellraw @s [{"text":"Let mobs with custom heads burn in daylight  [off]","bold":false,"color":"gray","hover_event":{"action":"show_text","value":[{"text":"This setting is getting controlled globally and can't be changed here."}]}}]
 execute if score $mobs_burn ts.mm.settings matches 2 run tellraw @s [{"text":"Let mobs with custom heads burn in daylight  [on]","bold":false,"color":"gray","hover_event":{"action":"show_text","value":[{"text":"This setting is getting controlled globally and can't be changed here."}]}}]
 
-function more_mobs:settings/hide_feedback/main
 playsound minecraft:block.dispenser.dispense master @s ~ ~ ~ 0.2 2

--- a/data/more_mobs/function/settings/hide_feedback/hide.mcfunction
+++ b/data/more_mobs/function/settings/hide_feedback/hide.mcfunction
@@ -1,4 +1,0 @@
-##by Tschipcraft
-
-gamerule sendCommandFeedback false
-schedule function more_mobs:settings/hide_feedback/unhide 1t

--- a/data/more_mobs/function/settings/hide_feedback/main.mcfunction
+++ b/data/more_mobs/function/settings/hide_feedback/main.mcfunction
@@ -1,5 +1,0 @@
-##by Tschipcraft
-
-execute store result score $gamerule.send_feedback ts.mm.settings run gamerule sendCommandFeedback
-
-execute if score $gamerule.send_feedback ts.mm.settings matches 1 run function more_mobs:settings/hide_feedback/hide

--- a/data/more_mobs/function/settings/hide_feedback/unhide.mcfunction
+++ b/data/more_mobs/function/settings/hide_feedback/unhide.mcfunction
@@ -1,3 +1,0 @@
-##by Tschipcraft
-
-gamerule sendCommandFeedback true

--- a/data/more_mobs/function/version_checker.mcfunction
+++ b/data/more_mobs/function/version_checker.mcfunction
@@ -2,7 +2,7 @@
 
 scoreboard objectives add ts.mm.version dummy
 execute store result score $global ts.mm.version run data get entity @r DataVersion
-execute unless score $global tvc_ignore matches 1 if score $global ts.mm.version matches 4600.. run tellraw @a [{"text":"[More Mobs] ","color":"gray"},{"text":"?","bold":true,"color":"gold"},{"text":" Future unknown Minecraft version above 1.21.9 detected! This data pack/mod may not work correctly anymore! Please make sure to check for updates in the menu! (","color":"gold"},{"text":"/trigger tschipcraft.menu","underlined":true,"color":"gold","click_event":{"action":"run_command","command":"/trigger tschipcraft.menu"},"hover_event":{"action":"show_text","value":"Click here","text":"Click here"}},{"text":")","color":"gold"}]
+execute unless score $global tvc_ignore matches 1 if score $global ts.mm.version matches 4700.. run tellraw @a [{"text":"[More Mobs] ","color":"gray"},{"text":"?","bold":true,"color":"gold"},{"text":" Future unknown Minecraft version above 1.21.11 detected! This data pack/mod may not work correctly anymore! Please make sure to check for updates in the menu! (","color":"gold"},{"text":"/trigger tschipcraft.menu","underlined":true,"color":"gold","click_event":{"action":"run_command","command":"/trigger tschipcraft.menu"},"hover_event":{"action":"show_text","value":"Click here","text":"Click here"}},{"text":")","color":"gold"}]
 # Note: 1.14x-1.20x uses the old folder names (function -> functions)
 
 # Announce version limitations

--- a/data/more_mobs/tags/worldgen/biome/is_dry.json
+++ b/data/more_mobs/tags/worldgen/biome/is_dry.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:desert",
+    "#minecraft:is_badlands",
+    "#minecraft:is_savanna",
+    "#minecraft:is_nether",
+    {"id": "#c:is_dry", "required": false},
+    {"id": "#minecraft:snow_golem_melts", "required": false}
+  ]
+}

--- a/data/tschipcraft/function/menu_header.mcfunction
+++ b/data/tschipcraft/function/menu_header.mcfunction
@@ -1,4 +1,3 @@
 ##by Tschipcraft
 
 tellraw @s {"text":"The following packs are installed:","color":"gold"}
-function more_mobs:settings/hide_feedback/main

--- a/overlay_pre_63/data/more_mobs/function/settings/core.mcfunction
+++ b/overlay_pre_63/data/more_mobs/function/settings/core.mcfunction
@@ -34,5 +34,4 @@ execute if score $global ts.mm.version matches 3330.. if score $mobs_burn ts.mm.
 execute if score $global ts.mm.version matches 3330.. if score $mobs_burn ts.mm.settings matches -1 run tellraw @s [{"text":"Let mobs with custom heads burn in daylight  [off]","bold":false,"color":"gray","hoverEvent":{"action":"show_text","contents":[{"text":"This setting is getting controlled globally and can't be changed here."}]}}]
 execute if score $global ts.mm.version matches 3330.. if score $mobs_burn ts.mm.settings matches 2 run tellraw @s [{"text":"Let mobs with custom heads burn in daylight  [on]","bold":false,"color":"gray","hoverEvent":{"action":"show_text","contents":[{"text":"This setting is getting controlled globally and can't be changed here."}]}}]
 
-function more_mobs:settings/hide_feedback/main
 playsound minecraft:block.dispenser.dispense master @s ~ ~ ~ 0.2 2

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -2,9 +2,9 @@
   "id": "moremobs",
   "pack": {
     "pack_format": 15,
-    "supported_formats": [4,88],
+    "supported_formats": [4,94],
     "min_format": 4,
-    "max_format": 88,
+    "max_format": 94,
     "description": "Tschipcraft's More Mobs \n└ v${version} ● mc${mc_human_version_range}"
   },
   "overlays": {


### PR DESCRIPTION
- **Added support for Minecraft 1.21.11** 🐎
  - Updated rain detection to use our own `#is_dry` biome tag combo instead of the now removed `#snow_golem_melts` tag
  - Removed broken hide feedback code for 1.21+
  - Bumped pack format and protocol version
- Hardcoded Forge version range to `[1.17,1.21.5]`